### PR TITLE
Remove `serde` as a dependency as not used anymore

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "symbolizer-rs"
 version = "0.1.0"
 edition = "2021"
 authors = ["Axel '0vercl0k' Souchet"]
-categories = ["command-line-utilities"]
+categories = ["command-line-utilities", "development-tools::debugging"]
 description = "A fast execution trace symbolizer for Windows that runs on all major platforms and doesn't depend on any Microsoft libraries."
 include = ["/Cargo.toml", "/LICENSE", "/src/**", "README.md"]
 keywords = ["windows", "kernel", "crash-dump", "symbols", "pdb"]
@@ -14,7 +14,6 @@ rust-version = "1.70"
 [dependencies]
 anyhow = "1.0"
 pdb = "0.8"
-serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
 env_logger = "0.11"
 clap = { version = "4.5", features = ["derive"] }


### PR DESCRIPTION
`serde` was used in very early prototypes and I somehow forgot to clean it up off the dependency list.