### PR TITLE
v0.4

### DIFF
--- a/.github/workflows/symbolizer-rs.yml
+++ b/.github/workflows/symbolizer-rs.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up rust
         run: rustup default stable
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up rust
         run: rustup default stable
@@ -59,7 +59,7 @@ jobs:
     name: build & test / ${{ matrix.os }}
     steps:
       - name: Checkout 
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up rust
         run: rustup default stable

--- a/.github/workflows/symbolizer-rs.yml
+++ b/.github/workflows/symbolizer-rs.yml
@@ -77,7 +77,7 @@ jobs:
         run: cargo build --release --all-targets
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: symbolizer-rs.${{ matrix.os }}
           path: |

--- a/.github/workflows/symbolizer-rs.yml
+++ b/.github/workflows/symbolizer-rs.yml
@@ -8,7 +8,7 @@ jobs:
     name: fmt
     steps:
       - name: Checkout 
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up rust
         run: rustup default nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "symbolizer-rs"
 categories = ["command-line-utilities", "development-tools::debugging"]
 description = "A fast execution trace symbolizer for Windows that runs on all major platforms and doesn't depend on any Microsoft libraries."
 include = ["/Cargo.toml", "/LICENSE", "/src/**", "README.md"]
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Axel '0vercl0k' Souchet"]
 license = "MIT"
 repository = "https://github.com/0vercl0k/symbolizer-rs"
@@ -13,7 +13,7 @@ edition = "2024"
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
-addr-symbolizer = "0.2"
+addr-symbolizer = {path = "../addr-symbolizer-rs" }
 env_logger = "0.11"
 itoa = "1.0"
 kdmp-parser = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2024"
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
-addr-symbolizer = { version = "0.3" }
+addr-symbolizer = "0.3"
 env_logger = "0.11"
 itoa = "1.0"
 kdmp-parser = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2024"
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }
-addr-symbolizer = {path = "../addr-symbolizer-rs" }
+addr-symbolizer = { version = "0.3" }
 env_logger = "0.11"
 itoa = "1.0"
 kdmp-parser = "0.8"

--- a/README.md
+++ b/README.md
@@ -109,19 +109,17 @@ Options:
 
           [default: 0]
 
-  -m, --max <MAX>
-          The maximum amount of lines to process per file
-
-          [default: 20000000]
+  -l, --limit <LIMIT>
+          The maximum amount of lines to process per file (defaults to 20m, use `0` for no limit)
 
       --style <STYLE>
           The symbolization style (mod+offset or mod!f+offset)
 
-          [default: full]
-
           Possible values:
           - modoff: Module + offset style like `foo.dll+0x11`
           - full:   Full symbol style like `foo.dll!func+0x11`
+
+          [default: full]
 
       --overwrite
           Overwrite the output files if they exist
@@ -129,13 +127,16 @@ Options:
       --line-numbers
           Include line numbers in the symbolized output
 
-      --symsrv <SYMSRV>
+      --symsrvs <SYMSRVS>
           Symbol servers to use to download PDBs; you can provide more than one
 
           [default: https://msdl.microsoft.com/download/symbols/]
 
-      --sympath <SYMPATH>
-          Specify a symbol path. If not specified, _NT_SYMBOL_PATH will be parsed if present
+      --symcache <SYMCACHE>
+          Specify a symbol cache path. If not specified, `_NT_SYMBOL_PATH` will be parsed if present
+
+      --import-pdbs <IMPORT_PDBS>
+          Import PDBs found in the specified directories into the symbol cache
 
       --out-buffer-size <OUT_BUFFER_SIZE>
           The size in bytes of the buffer used to write data into the output files
@@ -146,6 +147,9 @@ Options:
           The size in bytes of the buffer used to read data from the input files
 
           [default: 1048576]
+
+      --offline
+          Don't try to download PDBs off the network
 
   -h, --help
           Print help (see a summary with '-h')

--- a/src/main.rs
+++ b/src/main.rs
@@ -251,9 +251,9 @@ fn symbolize_file(
     let input = File::open(trace_path)
         .with_context(|| format!("failed to open {}", trace_path.display()))?;
 
-    let writer: Box<dyn Write> = match &args.output {
-        Some(output) => Box::new(get_output_file(args, trace_path, output)?),
-        None => Box::new(stdout()),
+    let writer: &mut dyn Write = match &args.output {
+        Some(output) => &mut get_output_file(args, trace_path, output)?,
+        None => &mut stdout(),
     };
 
     let mut output = BufWriter::with_capacity(args.out_buffer_size, writer);

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 use std::{env, fs, io};
 
-use addr_symbolizer::{AddrSpace, Builder as SymbolizerBuilder, Module, Symbolizer};
+use addr_symbolizer::{AddrSpace, Module, PdbLookupConfig, Symbolizer};
 use anyhow::{Context, Result, anyhow, bail};
 use clap::{ArgAction, Parser, ValueEnum};
 use kdmp_parser::parse::KernelDumpParser;
@@ -44,7 +44,7 @@ impl StatsBuilder {
         let stats = Stats {
             time: self.start.elapsed().as_secs(),
             n_files: self.n_files,
-            symbolizer_stats: symbolizer.stats(),
+            symbolizer_stats: symbolizer.stats().clone(),
         };
 
         drop(symbolizer);
@@ -80,7 +80,7 @@ impl Display for Stats {
                 f,
                 ", downloaded {} / {} PDBs)",
                 size_downloaded.human_bytes(),
-                self.symbolizer_stats.amount_pdb_downloaded().human_number()
+                self.symbolizer_stats.pdb_download_count().human_number()
             )
         } else {
             write!(f, ")")
@@ -117,6 +117,9 @@ enum SymbolStyle {
     Full,
 }
 
+/// The default maximum amount of lines to process per file.
+const DEFAULT_LIMIT: usize = 20_000_000;
+
 /// The command line arguments.
 #[derive(Debug, Default, Parser)]
 #[command(about = "A fast execution trace symbolizer for Windows.")]
@@ -135,8 +138,9 @@ struct CliArgs {
     /// Skip a number of lines.
     #[arg(short, long, default_value_t = 0)]
     skip: usize,
-    /// The maximum amount of lines to process per file.
-    #[arg(short, long, default_value = "20000000")]
+    /// The maximum amount of lines to process per file (defaults to 20m, use
+    /// `0` for no limit).
+    #[arg(short, long)]
     limit: Option<usize>,
     /// The symbolization style (mod+offset or mod!f+offset).
     #[arg(long, default_value = "full")]
@@ -149,7 +153,7 @@ struct CliArgs {
     line_numbers: bool,
     /// Symbol servers to use to download PDBs; you can provide more than one.
     #[arg(long, default_value = "https://msdl.microsoft.com/download/symbols/", action = ArgAction::Append)]
-    symsrv: Vec<String>,
+    symsrvs: Vec<String>,
     /// Specify a symbol cache path. If not specified, `_NT_SYMBOL_PATH` will be
     /// parsed if present.
     #[arg(long)]
@@ -159,10 +163,10 @@ struct CliArgs {
     import_pdbs: Option<Vec<PathBuf>>,
     /// The size in bytes of the buffer used to write data into the output
     /// files.
-    #[arg(long, default_value_t = 3 * 1024 * 1024)]
+    #[arg(long, default_value_t = 3 * 1_024 * 1_024)]
     out_buffer_size: usize,
     /// The size in bytes of the buffer used to read data from the input files.
-    #[arg(long, default_value_t = 1024 * 1024)]
+    #[arg(long, default_value_t = 1_024 * 1_024)]
     in_buffer_size: usize,
     /// Don't try to download PDBs off the network.
     #[arg(long, default_value_t = false)]
@@ -253,11 +257,17 @@ fn symbolize_file(
     };
 
     let mut output = BufWriter::with_capacity(args.out_buffer_size, writer);
-    let mut line_number = 1 + args.skip;
     let mut lines_symbolized = 1;
-    let limit = args.limit.unwrap_or(usize::MAX);
+    let limit = match args.limit.unwrap_or(DEFAULT_LIMIT) {
+        // The `0` value is used as a way to say "there's no limit".
+        0 => None,
+        rest => Some(rest),
+    };
+
     let reader = BufReader::with_capacity(args.in_buffer_size, input);
-    for addr in HexAddressesIterator::new(reader).skip(args.skip) {
+    for (line_number, addr) in
+        (1 + args.skip..).zip(HexAddressesIterator::new(reader).skip(args.skip))
+    {
         let addr = addr.with_context(|| {
             format!(
                 "failed to get hex addr from l{line_number} of {}",
@@ -273,8 +283,8 @@ fn symbolize_file(
         }
 
         match args.style {
-            SymbolStyle::Modoff => symbolizer.modoff(addr, &mut output),
-            SymbolStyle::Full => symbolizer.full(addr_space, addr, &mut output),
+            SymbolStyle::Modoff => symbolizer.symbolize_modoff_into(addr, &mut output),
+            SymbolStyle::Full => symbolizer.symbolize_full_into(addr_space, addr, &mut output),
         }
         .with_context(|| {
             format!(
@@ -285,7 +295,9 @@ fn symbolize_file(
 
         output.write_all(b"\n")?;
 
-        if lines_symbolized >= limit {
+        if let Some(limit) = limit
+            && lines_symbolized >= limit
+        {
             println!(
                 "Hit maximum line limit {} for {}",
                 limit,
@@ -295,7 +307,6 @@ fn symbolize_file(
         }
 
         lines_symbolized += 1;
-        line_number += 1;
     }
 
     Ok(lines_symbolized)
@@ -357,19 +368,16 @@ fn main() -> Result<()> {
 
     // All right, ready to create the symbolizer.
     let mut wrapper = AddrSpaceWrapper::new(parser);
-    let mut builder = SymbolizerBuilder::default()
-        .modules(modules)
-        .symcache(symcache)?;
+    let pdb_lookup = if args.offline {
+        PdbLookupConfig::new(symcache)
+    } else {
+        PdbLookupConfig::with_symsrvs(symcache, args.symsrvs.clone())
+    }?;
+    let mut symbolizer = Symbolizer::new(pdb_lookup, modules);
 
     if let Some(import_pdbs) = &args.import_pdbs {
-        builder = builder.import_pdbs(import_pdbs.iter())?;
+        symbolizer.import_pdbs(import_pdbs.iter())?;
     }
-
-    if !args.offline {
-        builder = builder.online(args.symsrv.iter());
-    }
-
-    let mut symbolizer = builder.build()?;
 
     let paths = if args.trace.is_dir() {
         // If we received a path to a directory as input, then we will try to symbolize


### PR DESCRIPTION
- Fix the `--limit` option; you can now pass `0` to lift the limit
- Rename `--symsrv` to `--symsrvs`
- Bump `addr-symbolizer` to `0.3`